### PR TITLE
Improve newrelic setup

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-require('newrelic');
+const newrelic = require('newrelic');
 
 import express from 'express';
 import compression from 'compression';
@@ -168,6 +168,7 @@ function handleRender(req, res) {
   const routes = _routes();
   match({ routes, location }, (error, redirectLocation, renderProps) => {
     console.info('--- Handling request: ', req.url);
+    newrelic.setTransactionName(req.url.substring(1));
 
     function getReduxPromise() {
       let comp = renderProps.components[renderProps.components.length - 1];

--- a/webpack/webpack-dev-server.js
+++ b/webpack/webpack-dev-server.js
@@ -1,3 +1,4 @@
+require('newrelic');
 var Express = require('express');
 var webpack = require('webpack');
 


### PR DESCRIPTION
- Ensure newrelic is loaded before all instances of express (webpack dev
  server)
- manually set newrelic transaction name for clarity