### PR TITLE
Fix search splitting on space

### DIFF
--- a/src/reducers/__tests__/search-test.js
+++ b/src/reducers/__tests__/search-test.js
@@ -2,11 +2,11 @@ import reducer, { initialState, collectionFilter } from '../search';
 import expect from 'expect';
 
 let mockData = [
-  { id: 1, first_name: 'John', tags: [{ name: 'hiv' }, { name: 'housing' }],
+  { id: 1, title: 'SOME', tags: [{ name: 'hiv' }, { name: 'housing' }],
     address: { street: '1234 Main street' } },
-  { id: 2, first_name: 'Jim', tags: [{ name: 'lgbt' }, { name: 'housing' }],
+  { id: 2, title: 'Therapy Center', tags: [{ name: 'lgbt' }, { name: 'housing' }],
     address: { street: '999 First st' } },
-  { id: 3, first_name: 'Bob', tags: [{ name: 'lgbt' }, { name: 'housing' }],
+  { id: 3, title: 'STI testing center', tags: [{ name: 'lgbt' }, { name: 'housing' }],
     address: null }
 ];
 
@@ -32,31 +32,31 @@ describe('Search Reducer', () => {
 
 describe('Collection Filter', () => {
   it('returns all if no search passed', () => {
-    let result = collectionFilter(mockData, '', ['first_name']);
+    let result = collectionFilter(mockData, '', ['title']);
     expect(result.length).toBe(3);
   });
 
   it('matches search value', () => {
-    let result = collectionFilter(mockData, 'Joh', ['first_name']);
+    let result = collectionFilter(mockData, 'SOM', ['title']);
     expect(result.length).toBe(1);
     expect(result[0].id).toBe(1);
   });
 
   it('matches case insensitive', () => {
-    let result = collectionFilter(mockData, 'JI', ['first_name']);
+    let result = collectionFilter(mockData, 'sti', ['title']);
     expect(result.length).toBe(1);
-    expect(result[0].id).toBe(2);
+    expect(result[0].id).toBe(3);
   });
 
   it('ignores fields that are not searched on', () => {
-    let result = collectionFilter(mockData, 'JI', ['id']);
+    let result = collectionFilter(mockData, 'SOM', ['id']);
     expect(result.length).toBe(0);
   });
 
   it('matches on space separated search values', () => {
-    let result = collectionFilter(mockData, 'John Smith', ['first_name']);
+    let result = collectionFilter(mockData, 'Therapy center', ['title']);
     expect(result.length).toBe(1);
-    expect(result[0].id).toBe(1);
+    expect(result[0].id).toBe(2);
   });
 
   it('matches against nested array fields', () => {
@@ -81,10 +81,10 @@ describe('Collection Filter', () => {
     expect(result.length).toBe(2);
   });
 
-  it('matches against subobject and main object', () => {
-    let result = collectionFilter(mockData, 'hiv 3', ['id', 'tags.name']);
+  it('matches against subObject and main object', () => {
+    let result = collectionFilter(mockData, 'lgbt', ['id', 'tags.name']);
     expect(result.length).toBe(2);
-    expect(result[0].id).toEqual(1);
+    expect(result[0].id).toEqual(2);
     expect(result[1].id).toEqual(3);
   });
 });

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -27,7 +27,7 @@ function compareValues(value, input) {
 }
 
 export function collectionFilter(collection, input = '', fields = []) {
-  let inputs = input.split(/\s|-|\+/g);
+  let inputs = input.trim().split(/\-|\+/g);
 
   return _filter(collection, object => (
     _some(fields, field => {


### PR DESCRIPTION
- Remove splitting on space when searching resources. Allows for more
  precise results. It was previously over-matching