### PR TITLE
Fix styling of tags in ResourceRow

### DIFF
--- a/src/components/ResourceRow/ResourceRow.js
+++ b/src/components/ResourceRow/ResourceRow.js
@@ -21,11 +21,12 @@ export default class ResourceRow extends Component {
       title
     } = this.props;
 
+    require('./ResourceRow.scss');
     return (<Link className="list-group-item" to={`/resources/${id}`}>
       <h4>{title}</h4>
       <MultilineValue value={description}/>
 
-      {displayTags && <div>{tags.map((tag, i) => (
+      {displayTags && <div className="tag-group">{tags.map((tag, i) => (
         <span key={i} className="tokenized-tag">{tag.name}</span>
       ))}</div>}
     </Link>);

--- a/src/components/ResourceRow/ResourceRow.scss
+++ b/src/components/ResourceRow/ResourceRow.scss
@@ -1,0 +1,3 @@
+.tag-group {
+  margin-top: 10px;
+}


### PR DESCRIPTION
- Add some margin top to fix the styling so it doesn't run right up
  against the resource description