### PR TITLE
Fix EB deploy script

### DIFF
--- a/.ebextensions/01run.config
+++ b/.ebextensions/01run.config
@@ -5,8 +5,8 @@ commands:
     command: "ln -sf `ls -td /opt/elasticbeanstalk/node-install/node-* | head -1`/bin/npm /bin/npm"
   03_global_install_webpack:
     command: sudo npm install -g webpack
-  04_global_install_babel:
-    command: sudo npm install -g babel
+#  04_global_install_babel:
+#    command:  #sudo npm install -g babel
 
 files:
   "/opt/elasticbeanstalk/hooks/appdeploy/pre/50npm.sh" :


### PR DESCRIPTION
- Remove babel as install dependency. It was added as a default to EB?