### PR TITLE
Fix FormGroup placeholder function

### DIFF
--- a/src/__tests__/acceptance/core-test.js
+++ b/src/__tests__/acceptance/core-test.js
@@ -139,6 +139,12 @@ describe('Acceptance - App', () => {
 
     expect(currentURL()).toBe('/questions');
     expect(wrapper.find('.questionForm').length).toBe(2);
+    click(wrapper.find('.fa-pencil').first());
+
+    await pause();
+
+    // TODO(jd): Fix this test. Why doesn't this trigger
+    // expect(wrapper.find('input#stem').length).toBe(1);
   }));
 
   it('renders tags', asyncTest(async () => {

--- a/src/components/FormGroup/FormGroup.js
+++ b/src/components/FormGroup/FormGroup.js
@@ -88,6 +88,20 @@ export default class FormGroup extends Component {
     return isEditing === undefined ? true : isEditing;
   }
 
+  placeholder() {
+    let label = this.label();
+    let placeholder = this.props.placeholder;
+    let val = '';
+
+    if (placeholder) {
+      val = placeholder;
+    } if (label) {
+      val = `Enter ${label.toLowerCase()}`
+    }
+
+    return val
+  }
+
   type() {
     let { type } = this.props;
     let val;
@@ -104,7 +118,6 @@ export default class FormGroup extends Component {
   render() {
     let {
       name,
-      placeholder,
       error,
       labelClassName,
       wrapperClassName,
@@ -120,7 +133,7 @@ export default class FormGroup extends Component {
           label={this.label()}
           type={this.type()}
           id={name}
-          placeholder={placeholder || `Enter ${this.label().toLowerCase()}`}
+          placeholder={this.placeholder()}
           bsStyle={error ? 'error' : null}
           help={error}
           children={children}

--- a/src/components/FormGroup/FormGroup.js
+++ b/src/components/FormGroup/FormGroup.js
@@ -3,6 +3,7 @@ import FormControls from 'react-bootstrap/lib/FormControls/Static';
 import Input from 'react-bootstrap/lib/Input';
 import string from 'src/utils/string';
 import _isArray from 'lodash/isArray';
+import _isString from 'lodash/isArray';
 
 import { MultilineValue } from 'src/components';
 
@@ -95,7 +96,7 @@ export default class FormGroup extends Component {
 
     if (placeholder) {
       val = placeholder;
-    } if (label) {
+    } if (_isString(label)) {
       val = `Enter ${label.toLowerCase()}`
     }
 

--- a/src/components/MultilineValue/MultilineValue.js
+++ b/src/components/MultilineValue/MultilineValue.js
@@ -14,13 +14,9 @@ export default class MultilineValue extends Component {
     seeMoreLink: PropTypes.string,
   };
 
-  static defaultProps = {
-    value: ''
-  }
-
   render() {
     let { value, seeMoreLink, truncate } = this.props;
-    let _value = value.split('\n').filter((v) => v.length);
+    let _value = (value || '').split('\n').filter((v) => v.length);
     let isTruncating = truncate && _value.length > truncate;
 
     if (isTruncating) {


### PR DESCRIPTION
- `label` prop to FormGroup can be a boolean as well (don't show the
  label) and we were calling toLowerCase() on the boolean. Abstracted
the logic out to a separate function that ensures we call it only on a
string

- Slight adjustment to MultilineValue to ensure the value is a string
  before splitting